### PR TITLE
"weil-am-rhein" replaced with "dreilaendereck"

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -61,5 +61,5 @@
 	"reihen" : "http://freifunk.reihen.de/reihen.json",
 	"hannover" : "http://kreutzer.biz/hannover-api.json",
 	"erfurt" : "http://sj.weimarnetz.de/freifunk/ff-erfurt.json",
-	"weil-am-rhein" : "https://raw.github.com/kalbfuss/Freifunk-Weil-am-Rhein/master/ffapi.json"
+	"dreilaendereck" : "https://raw.githubusercontent.com/kalbfuss/freifunk-dreilaendereck/master/ffapi.json"
 }


### PR DESCRIPTION
- Obsoleter Eintrag für die Community "weil-am-rhein" entfernt.
- Neuer Eintrag für die Community "dreilaendereck" hinzugefügt
