### PR TITLE
URL of API file for Braunschweig changed

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -8,7 +8,7 @@
 	"bielefeld" : "http://vpn1.freifunk-bielefeld.de/freifunk/ffapi.json",
 	"bochum" : "http://freifunk-ruhrgebiet.de/ffapi/bochum.json",
 	"bonn" : "http://map.kbu.freifunk.net/ffapi/bonn.json",
-	"braunschweig" : "http://freifunk.stratum0.org/api/api.json",
+	"braunschweig" : "http://freifunk-bs.de/api.json",
 	"bremen" : "http://bremen.freifunk.net/ffapi/bremen.json",
 	"brilon" : "http://freifunk-brilon.net/map/generator/ffb_api.json",
 	"chemnitz" : "http://api.routers.chemnitz.freifunk.net/request.php?apikey=f666e95f44c2a54c90f408a2043e30d970fc5f1b&type=com.ffc.info.general",


### PR DESCRIPTION
The location of the API file for Freifunk Braunschweig has changed.
