### PR TITLE
change name from rheinland to rheinufer

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -106,7 +106,7 @@
 	"reihen" : "http://freifunk.reihen.de/reihen.json",
 	"remscheid" : "http://rs.freifunk.net/api.json",
 	"rheinfelden" : "http://gw2.freifunk-rheinfelden.de/ff3l.json",
-	"rheinland" : "https://freifunk-rheinland.net/ffapi.json",
+	"rheinufer" : "https://freifunk-rheinland.net/ffapi.json",
 	"rhein-neckar" : "http://ffapi.freifunk-rhein-neckar.de/rhein-neckar.json",
 	"rostock" : "http://www.opennet-initiative.de/api.freifunk.net-status.json",
 	"rothenburg" : "http://freifunk-rothenburg.de/rothenburg.json",


### PR DESCRIPTION
The correct name of this meta community (domain) is rheinufer.
This domain is part of the Freifunk Rheinland e.V.
