### PR TITLE
Update Wermelskirchen (Versuch 2)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -134,7 +134,7 @@
 	"warendorf" : "https://raw.githubusercontent.com/ffmus/ffapi/master/warendorf.json",
 	"weimarnetz" : "http://weimarnetz.de/weimarnetz.json",
 	"weinstadt" : "http://freifunk-weinstadt.de/TJxlxN0f",
-	"wermelskirchen" : "http://wk.freifunk.net/api.json",
+	"wermelskirchen" : "http://nodeapi.vfn-nrw.de/index.php/get/community/3/format/ffapi",
 	"werne" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/werne.json",
 	"wesel" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/wesel.json",
 	"westpfalz" : "http://api.freifunk-westpfalz.de/FreifunkWestpfalz-api.json",


### PR DESCRIPTION
Ich habe die Ausgabe unseres Generators unter http://freifunk.net/api-generator/ getestet. Es sollte jetzt alles stimmen. Auf das erste Request habe ich keine Reaktion mehr erhalten, daher reiche ich es nochmal ein.