### PR TITLE
Community Düren hinzufügen

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -30,6 +30,7 @@
 	"dortmund" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/dortmund.json",
 	"dreilaendereck" : "https://raw.githubusercontent.com/kalbfuss/freifunk-dreilaendereck/master/ffapi.json",
 	"dresden" : "http://info.ddmesh.de/info/freifunk.json",
+	"dueren" : "http://wiki.freifunk.net/images/0/06/FreifunkDüren-api.json",
 	"duesseldorf" : "https://raw.githubusercontent.com/ffrl/FF-API-Rheinufer/master/duesseldorf.json",
 	"ehingen" : "http://freifunk-ehingen.de/FreifunkEhingen-api.json",
 	"eifel" : "http://map.kbu.freifunk.net/ffapi/eifel.json",


### PR DESCRIPTION
Hallo,

ich habe im Wiki die Community Düren angelegt und möchte erstmal die Basiseintrag in die Map bekommen. Beim nächsten Treffen ergänzen wir dann weitere Meta Infos.

Beste Grüße

Markus