### PR TITLE
changed bamberg to bamberg (Freifunk Franken)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -6,7 +6,7 @@
 	"augsburg": "http://www.wgaugsburg.de/ffapi/ffapi.json",
 	"badgandersheim" : "http://argarh.de/FFGAN/FreifunkBadGandersheim-api.json",
 	"badoeynhausen" : "http://www.freifunk-badoeynhausen.de/ffapi/FreifunkBadOeynhausen-api.json",
-	"bamberg" : "http://vpn1.freifunk-bamberg.de/ffapi/ffba-api.json",
+	"bamberg" : "https://rawgit.com/FreifunkFranken/freifunkfranken-community/master/bamberg.json",
 	"battlemesh" : "http://feeds.leipzig.freifunk.net/ffapi/battlemesh.json",
 	"berlin" : "http://berlin.freifunk.net/static/berlin.json",
 	"bielefeld" : "http://vpn1.freifunk-bielefeld.de/freifunk/ffapi.json",


### PR DESCRIPTION
ACHTUNG nicht einfach mergen!
Das Thema muss erst gellärt werden. Diskussion siehe #137