### PR TITLE
Freifunk Ibbenbueren

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -77,6 +77,7 @@
 	"hockenheim" : "https://raw.githubusercontent.com/Nurtic-Vibe/FF-Hockenheim-Nodes/master/ff-hockenheim-api.json",
 	"hof" : "https://rawgit.com/FreifunkFranken/freifunkfranken-community/master/hof.json",
 	"hueckeswagen" : "http://nodeapi.vfn-nrw.de/index.php/get/community/21/format/ffapi",
+	"ibbenbueren" : "https://raw.githubusercontent.com/ff-ibb/ff-api/master/FreifunkIbbenbueren.json",
 	"ingolstadt" : "https://freifunk-ingolstadt.de/ffapi.json",
 	"iserlohn" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/iserlohn.json",
 	"jena" : "http://freifunk-jena.de/jena.json",


### PR DESCRIPTION
Freifunk Ibbenbüren ohne Umlaute