### PR TITLE
Update Location of Dueren API-File

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -31,7 +31,7 @@
 	"dortmund" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/dortmund.json",
 	"dreilaendereck" : "https://raw.githubusercontent.com/kalbfuss/freifunk-dreilaendereck/master/ffapi.json",
 	"dresden" : "http://info.ddmesh.de/info/freifunk.json",
-	"dueren" : "http://wiki.freifunk.net/images/0/06/FreifunkDüren-api.json",
+	"dueren" : "https://wiki.freifunk.net/images/6/69/Dnffapi.json",
 	"duesseldorf" : "https://raw.githubusercontent.com/ffrl/FF-API-Rheinufer/master/duesseldorf.json",
 	"ehingen" : "http://freifunk-ehingen.de/FreifunkEhingen-api.json",
 	"eifel" : "http://map.kbu.freifunk.net/ffapi/eifel.json",


### PR DESCRIPTION
URL with Umlauts does not seem to work.
Created new API file at location without umlauts.
See https://github.com/freifunk/directory.api.freifunk.net/pull/139#issuecomment-86127799