### PR TITLE
Freifunk Aachen API file now hosted on Github

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -1,5 +1,5 @@
 {
-	"aachen" : "http://www.freifunk-aachen.de/acffapi.json",
+	"aachen" : "https://raw.githubusercontent.com/ffac/api-file/master/acffapi.json",
 	"altdorf" : "http://freifunk-altdorf.de/FreifunkAltdorf-api.json",
 	"altmark" : "http://feeds.leipzig.freifunk.net/ffapi/altmark.json",
 	"ansbach" : "https://raw.githubusercontent.com/ffansbach/community-files/master/ansbach.json",


### PR DESCRIPTION
Hallo liebe Directory-Maintainer,

wir haben uns entschlossen, unser API file nun auf Github zu verwalten ([Link][1]). Hier ist die dazu nötige Änderung für das Directory.

Gruß
David


[1]: https://github.com/ffac/api-file