### PR TITLE
Update neuer Ablageort neukirchen-vluyn.json

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -142,7 +142,7 @@
 	"muensterland" : "https://freifunk-muensterland.de/freifunk/ffapi.json",
 	"nettetal" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/nettetal.json",
 	"neuendettelsau" : "https://netmon.freifunk-neuendettelsau.de/api/community.php",
-	"neukirchen-vluyn" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/neukirchen-vluyn.json",
+	"neukirchen-vluyn" : "http://freifunk-nv.de/ff-api/neukirchen-vluyn.json",
 	"neuss" : "https://raw.githubusercontent.com/ffrl/FF-API-Rheinufer/master/neuss.json",
 	"niex" : "https://www.opennet-initiative.de/freifunk/api.freifunk.net-niex.json",
 	"nuernberg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/nuernberg.json",


### PR DESCRIPTION
Die API-File mit den korrigierten Daten wurde nun auf unserem Community Server abgelegt. Ich bitte um Eintragung. Danke!