### PR TITLE
Freifunk Haßloch hinzugefügt

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -90,6 +90,7 @@
 	"hannover" : "http://kreutzer.biz/hannover-api.json",
 	"harz" : "http://harz.freifunk.net/api.json",
 	"hassberge" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/hassberge.json",
+	"hassloch" : "https://www.freifunk-hassloch.de/freifunk-hassloch.json",
 	"hattingen" : "http://freifunk-hattingen.de/hattingen.json",
 	"helgoland" : "https://meta.hamburg.freifunk.net/Helgoland-api.json",
 	"hennef" : "http://www.freifunk-hennef.de/wp-content/api/ff-hennef-api.json",


### PR DESCRIPTION
Freifunk Haßloch als Unter-Community von Freifunk Südpfalz eingetragen