### PR TITLE
Update directory.json

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -45,7 +45,7 @@
 	"cottbus" : "https://freifunk-cottbus.de/FreifunkCottbus-api.json",
 	"crailsheim": "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/crailsheim.json",
 	"darmstadt" : "https://api.darmstadt.freifunk.net/ffapi.json",
-	"datteln" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/datteln.json",
+	"datteln" : "https://freifunk-ostvest.de/FreifunkOstvest-api.json",
 	"detmold": "http://update.freifunk-nordlippe.de/ffapi_detmold.json",
 	"dillingen" : "http://freifunk-saar.de/ffs.json",
 	"dithmarschen" : "https://raw.githubusercontent.com/Freifunk-Nord/nord-community-api/master/dithmarschen-api.json",


### PR DESCRIPTION
Wir haben die Domäne Ostvest neu aufgesetzt, welche in Zukunft die Städte Oer-Erkenschwick, Datteln, Waltrop, Castrop-Rauxel und vorraussichtlich ncoh Olfen umfasst. Unsere Map befindet sich unter map.ffov.de. Wir würden dies gerne eintragen lassen. Auch die Nodes sollen eingetragen werden, welche unter map.ffov.de/data/nodes.json zu finden sein sollten.