### PR TITLE
Eintrag Donau-Ries, Löschung Donauwörth

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -56,7 +56,7 @@
 	"dillingen" : "http://freifunk-saar.de/ffs.json",
 	"dithmarschen" : "https://mesh.nord.freifunk.net/nord-community-api/dithmarschen-api.json",
 	"doebeln": "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkDoebeln-api.json",
-	"donauwoerth": "http://www.freifunk-donau-ries.de/FreifunkDonauwoerth.json",
+	"donauries": "http://services.ffdon.de/freifunk/ffapi.json",
 	"dorsten" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/dorsten.json",
 	"dortmund" : "https://raw.githubusercontent.com/ffdo/ffapi/master/dortmund.json",
 	"dresden" : "http://api.freifunk-dresden.de/freifunk-info.json",


### PR DESCRIPTION
Wind sind derzeit 1 Landkreisweite Community mit mehreren Domänen
Donauwörth ist Große Kreisstadt des Donau-Ries.
https://de.wikipedia.org/wiki/Landkreis_Donau-Ries