### PR TITLE
Freifunk Friedrichshafen (Metacommunity Freifunk Bodensee)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -80,6 +80,7 @@
 	"frankenberg" : "https://api.freifunk-fkb.de/FreifunkFrankenberg-api.json",
 	"frankfurt_am_main" : "https://api.ffm.freifunk.net/ff-frankfurt.json",
 	"freiburg" : "https://freiburg.freifunk.net/API-File",
+	"friedrichshafen" : "https://raw.githubusercontent.com/ffbsee/api/master/fffriedrichshafen.json",
 	"fuerth" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/fuerth.json",
 	"fulda" : "https://fulda.freifunk.net/FreifunkFulda-api.json",
 	"daendorf" : "https://www.opennet-initiative.de/freifunk/api.freifunk.net-daendorf.json",


### PR DESCRIPTION
Pull Request zum hinzufügen der Freifunk Community Freifunk Friedrichshafen, die ein Teil der Metacommunity Freifunk Bodensee ist!