### PR TITLE
Change link for Freifunk Erfurt to new destination

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -68,7 +68,7 @@
 	"eltville" : "https://www.freifunk-rheingau.de/ffapi_rheingau.json",
 	"emskirchen" : "https://netmon.freifunk-emskirchen.de/api/community.php",
 	"engelskirchen" : "https://nodeapi.vfn-nrw.de/index.php/get/community/42/format/ffapi",
-	"erfurt" : "http://sj.weimarnetz.de/freifunk/ff-erfurt.json",
+	"erfurt" : "https://api.erfurt.freifunk.net/freifunk-api.json",
 	"erlangen" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/erlangen.json",
 	"essen" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/essen.json",
 	"essingen" : "http://www.freifunk-essingen.de/wp-content/uploads/FreifunkEssingen-api.json",


### PR DESCRIPTION
We moved our api file from a server of a member to our own community subdomain