### PR TITLE
Update Freifunk Vogtland

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -249,6 +249,7 @@
 	"neuenrade" : "https://raw.githubusercontent.com/freifunk-mk/ff-api/master/neuenrade.json",
 	"neuensalz" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-NSZ.json",
 	"neukirchen-vluyn" : "http://freifunk-nv.de/ff-api/neukirchen-vluyn.json",
+	"neumark" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-NMK.json",
 	"neumuenster" : "https://nord.freifunk.net/api/neumuenster-api.json",
 	"neunkirchen" : "https://mgmt.saar.freifunk.net/data/api-neunkirchen.json",
 	"neunkirchen-seelscheid" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/neunkirchen.json",

--- a/directory.json
+++ b/directory.json
@@ -77,6 +77,7 @@
 	"eberswalde" : "http://ewifi.de/FreifunkEberswalde-api.json",
 	"efringen-kirchen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Efringen-Kirchen&country=DE&community=ff3l-loe",
 	"eggerbach" : "https://wiki.freifunk.net/images/9/9f/FreifunkEggerbach-api.json",
+	"ellefeld" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-ELL.json",
 	"eltville" : "https://www.freifunk-rtk.de/ffapi_rtk.json",
 	"emskirchen" : "https://netmon.freifunk-emskirchen.de/api/community.php",
 	"engelskirchen" : "https://nodeapi.vfn-nrw.de/index.php/get/community/42/format/ffapi",

--- a/directory.json
+++ b/directory.json
@@ -236,6 +236,7 @@
 	"monheim" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/MonheimamRhein-api.json",
 	"montabaur" : "https://freifunk-westerwald.de/api.json",
 	"much" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/much.json",
+	"muehlental" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-MTL.json",
 	"muelheim" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/muelheim.json",
 	"muenchen" : "https://raw.githubusercontent.com/freifunkMUC/freifunk.net-API/master/freifunk.net.json",
 	"muenden" : "https://freifunk-muenden.de/ffapi/muenden.json",

--- a/directory.json
+++ b/directory.json
@@ -309,7 +309,7 @@
 	"sanktaugustin" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/sankt-augustin.json",
 	"schleswig" : "https://nord.freifunk.net/api/schleswig-api.json",
 	"schmitzingen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Schmitzingen&country=DE&community=ff3l-ref",
-	"schoeneck" : "http://storage.freifunk-vogtland.net/ffapi-schoeneck.json",
+	"schoeneck" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-S.json",
 	"schoeningen" : "http://freifunk-elm-lappwald.de/api/schoeningen.json",
 	"schoenau-im-schwarzwald" : "https://map.freifunk-3laendereck.net/api/community.php?city=Sch%C3%B6nau+im+Schwarzwald&country=DE&community=ff3l-wiese",
 	"schoeppenstedt" : "http://freifunk-elm-lappwald.de/api/schoeppenstedt.json",

--- a/directory.json
+++ b/directory.json
@@ -335,6 +335,7 @@
 	"sprockhoevel" : "https://map.ff-en.de/ffapi/sprockhoevel.json",
 	"st-wendel" : "https://mgmt.saar.freifunk.net/data/api-st-wendel.json",
 	"stade" : "https://nord.freifunk.net/api/stade-api.json",
+	"steinberg" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-SBG.json",
 	"steinburg" : "https://nord.freifunk.net/api/steinburg-api.json",
 	"steinen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Steinen&country=DE&community=ff3l-wiese",
 	"stetten" : "https://map.freifunk-3laendereck.net/api/community.php?city=Stetten&country=DE&community=ff3l-loe",

--- a/directory.json
+++ b/directory.json
@@ -279,6 +279,7 @@
 	"pinneberg" : "https://pinneberg.freifunk.net/ffapi.json",
 	"plauen" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-PL.json",
 	"ploen" : "https://nord.freifunk.net/api/ploen-api.json",
+	"poehl" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-POE.json",
 	"potsdam" : "http://freifunk-potsdam.de/ffapi.json",
 	"pulheim" : "http://api.freifunk-rhein-erft.de/FreifunkRhein-Erft-api.json",
 	"radevormwald" : "http://api.freifunk-radevormwald.de/ffrade-api.json",

--- a/directory.json
+++ b/directory.json
@@ -136,6 +136,7 @@
 	"hattingen" : "https://map.ff-en.de/ffapi/hattingen.json",
 	"heiligenhaus" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Heiligenhaus-api.json",
 	"heilsbronn": "https://netmon.freifunk-heilsbronn.de/api/community.php",
+	"heinsdorfergrund" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-HDG.json",
 	"helgoland" : "https://meta.helgoland.freifunk.net/Helgoland-api.json",
 	"helmstedt" : "http://freifunk-elm-lappwald.de/api/helmstedt.json",
 	"hemer": "https://raw.githubusercontent.com/freifunk-mk/ff-api/master/hemer.json",

--- a/directory.json
+++ b/directory.json
@@ -247,6 +247,7 @@
 	"neuenburg-am-rhein" : "https://map.freifunk-3laendereck.net/api/community.php?city=Neuenburg+am+Rhein&country=DE&community=ff3l-loe",
 	"neuendettelsau" : "https://netmon.freifunk-neuendettelsau.de/api/community.php",
 	"neuenrade" : "https://raw.githubusercontent.com/freifunk-mk/ff-api/master/neuenrade.json",
+	"neuensalz" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-NSZ.json",
 	"neukirchen-vluyn" : "http://freifunk-nv.de/ff-api/neukirchen-vluyn.json",
 	"neumuenster" : "https://nord.freifunk.net/api/neumuenster-api.json",
 	"neunkirchen" : "https://mgmt.saar.freifunk.net/data/api-neunkirchen.json",


### PR DESCRIPTION
The Schoeneck API file wasn't update since more than a year. So it should be removed from the directory and replaced by the automatically generated API file.

There were also some activities by Freifunk Vogtland in regions which weren't yet listed in the directory.

* Ellefeld
* Heinsdorfergrund
* Mühlental
* Neuensalz
* Neumark
* Pöhl
* Steinberg