### PR TITLE
Add Esslingen

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -92,6 +92,7 @@
 	"erlangen" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/erlangen.json",
 	"essen" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/essen.json",
 	"essingen" : "http://www.freifunk-essingen.de/wp-content/uploads/FreifunkEssingen-api.json",
+	"esslingen" : "https://www.freifunk-esslingen.de/FreifunkEsslingen-api.json",
 	"eschweiler" : "https://www.freifunk-eschweiler.de/ffesc.json",
 	"euskirchen" : "https://ffeu.de/ffapi.json",
 	"falkenstein" : "https://vpn01.freifunk-vogtland.net/ffv/ffapi-FST.json",


### PR DESCRIPTION
API-Entry for FF Esslingen a. N.
(Nicht zu verwechseln mit Essingen)