### PR TITLE
change path for lauenburg

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -204,7 +204,7 @@
 	"landshut" : "https://raw.githubusercontent.com/tecff/freifunk.net-API/master/landshut.freifunk.net.json",
 	"langballig" : "http://api.ffslfl.net/langballig-api.json",
 	"lauchringen" : "Https://map.freifunk-3laendereck.net/api/community.php?city=Lauchringen&country=DE&community=ff3l-wtk",
-	"lauenburg" : "http://www.freifunk-lauenburg.de/assets/ffapi/FreifunkHerzogtumLauenburg-api.json",
+	"lauenburg" : "https://raw.githubusercontent.com/ffod/api/master/lauenburg.json",
 	"landau" : "http://freifunk-suedpfalz.de/FreifunkSuedpfalz-landau-api.json",
 	"lauf_an_der_pegnitz" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/lauf_an_der_pegnitz.json",
 	"leer" : "http://www.leeraner-freifunk.de/LeeranerFreifunk-api.json",


### PR DESCRIPTION
we lost the domain "freifunk-lauenburg.de"...