### PR TITLE
delete eschweiler

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -94,7 +94,6 @@
 	"essen" : "https://raw.githubusercontent.com/ffruhr/ffapi/master/essen.json",
 	"essingen" : "http://www.freifunk-essingen.de/wp-content/uploads/FreifunkEssingen-api.json",
 	"esslingen" : "https://www.freifunk-esslingen.de/FreifunkEsslingen-api.json",
-	"eschweiler" : "https://www.freifunk-eschweiler.de/ffesc.json",
 	"euskirchen" : "https://ffeu.de/ffapi.json",
 	"falkenstein" : "https://mapdata.freifunk-vogtland.net/ffapi-FST.json",
 	"flensburg" : "http://freifunk-flensburg.de/api/api.json",


### PR DESCRIPTION
Email von Samuel Hillesheim [shillesheim@comovision.de] v. 08.01.2019
Guten Tag, 
Die Seite von uns wird nicht weiter betrieben und das läuft unter der Aachener Seite. Bitte entfernt die API Verbindung.
Bis dann
Samuel