### PR TITLE
API file for rheinbach updated and moved to web-server

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -322,7 +322,7 @@
 	"rendsburg-eckernfoerde" : "https://nord.freifunk.net/api/rendsburg-eckernfoerde-api.json",
 	"rheinfelden-ch" : "https://map.freifunk-3laendereck.net/api/community.php?city=Rheinfelden&country=CH&community=3land",
 	"rheinfelden-de" : "https://map.freifunk-3laendereck.net/api/community.php?city=Rheinfelden&country=DE&community=hoho",
-	"rheinbach" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/rheinbach.json",
+	"rheinbach" : "https://freifunk-rheinbach.de/freifunk-rheinbach-api.json",
 	"rheinberg" : "http://freifunk-rheinberg.de/FreifunkRheinberg-api.json",
 	"riedern-am-wald" : "https://map.freifunk-3laendereck.net/api/community.php?city=Riedern+am+Wald&country=DE&community=wald",
 	"rodewisch" : "https://mapdata.freifunk-vogtland.net/ffapi-RDW.json",


### PR DESCRIPTION
Hello,

I have updated the API file for rheinbach and moved the file to our web-servers root directory.
 
[freifunk-rheinbach.de](https://freifunk-rheinbach.de/freifunk-rheinbach-api.json

Best regards
Thomas