### PR TITLE
delete hueckeswagen

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -165,7 +165,6 @@
 	"himmelpfort" : "https://hksc.de/freifunk.himmelpfort.json",
 	"hoechenschwand" : "https://map.freifunk-3laendereck.net/api/community.php?city=H%C3%B6chenschwand&country=DE&community=sswo",
 	"hof" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/hof.json",
-	"hueckeswagen" : "https://nodeapi.vfn-nrw.de/index.php/get/community/21/format/ffapi",
 	"huenxe" : "http://freifunk-huenxe.de/api/FreifunkHuenxe-api.json",
 	"huerup" : "http://api.ffslfl.net/huerup-api.json",
 	"ibbenbueren" : "https://raw.githubusercontent.com/ff-ibb/ff-api/master/FreifunkIbbenbueren.json",


### PR DESCRIPTION
Server Error E0004: Community mit dieser ID existiert nicht.
siehe auch [https://www.rga.de/lokales/hueckeswagen/freies-w-lan-deutlich-schneller-12313756.html](https://www.rga.de/lokales/hueckeswagen/freies-w-lan-deutlich-schneller-12313756.html)