### PR TITLE
Neue Freifunk Community aus Barnstorf

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -23,6 +23,7 @@
 	"bad-saeckingen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Bad+S%C3%A4ckingen&country=DE&community=saek",
 	"ballenstedt" : "http://harz.freifunk.net/api.bal.json",
 	"bamberg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/bamberg.json",
+	"barnstorf": "https://www.meiksbar.de/technik/freifunk/barnstorf.json",
 	"barntrup": "http://update.freifunk-nordlippe.de/ffapi_barntrup.json",
 	"beilngries" : "https://map.freifunk-altmuehltal.de/data/api/ffbei.json",
 	"berau" : "https://map.freifunk-3laendereck.net/api/community.php?city=Berau&country=DE&community=sswo",


### PR DESCRIPTION
Neue json-File mit richtigem Link: https://www.meiksbar.de/technik/freifunk/barnstorf.json