### PR TITLE
Freifunk Wolfen

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -434,6 +434,7 @@
 	"wetzlar" : "https://freifunk-wetzlar.de/ffwz-api.json",
 	"wittmund" : "https://dev.ffnw.de/api_files/Freifunk-Wittmund-Api.json",
 	"wokern" : "https://www.opennet-initiative.de/freifunk/api.freifunk.net-wokern.json",
+	"wolfen" : "https://raw.githubusercontent.com/Freifunk-Wolfen/api.freifunk.net-interface/master/api.json",
 	"wuelfrath" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Wuelfrath-api.json",
 	"wuerzburg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/wuerzburg.json",
 	"wuppertal" : "http://api.freifunk-wuppertal.net/ffnet/ffwtal.json",


### PR DESCRIPTION
Hi,

wir machen jetzt auch etwas Freifunk in Wolfen.
Ich folge der Anleitung:
- https://freifunk.net/wie-mache-ich-mit/lokale-gruppe-gruenden/ ->
- https://blog.freifunk.net/2014/03/25/6-schritten-zum-apifile/