### PR TITLE
deleted: castrop as it is no longer a community, it is now a technica…

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -54,7 +54,6 @@
 	"burscheid" : "http://api.gl.wupper.freifunk-rheinland.net/bcd.json",
 	"butzbach" : "https://www.freifunk-butzbach.de/download/freifunk-butzbach-api.json",
 	"calw" : "https://map.freifunk-3laendereck.net/api/community.php?community=ffng&country=DE&city=Calw",
-	"castrop" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/castrop.json",
 	"chemnitz" : "https://api.chemnitz.freifunk.net/chemnitz.json",
 	"coburg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/coburg.json",
 	"colditz" : "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkColditz-api.json",


### PR DESCRIPTION
…l domain in Freifunk Ostvest

I got the info from Daniel Toschke (Freifunk Ostvest) today, that there is no longer a Freifunk Castrop-Rauxel community, but a Castrop domain in Freifunk Ostvest to handle the existing nodes.
Community API file should be droped for that reason, after it has been unlinked in API directory.