### PR TITLE
stuttgart: update API URL

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -330,7 +330,7 @@
 	"stetten" : "https://map.freifunk-3laendereck.net/api/community.php?city=Stetten&country=DE&community=loe",
 	"strittmatt" : "https://map.freifunk-3laendereck.net/api/community.php?city=Strittmatt&country=DE&community=hotz",
 	"stuehlingen" : "https://map.freifunk-3laendereck.net/api/community.php?city=St%C3%BChlingen&country=DE&community=wtk",
-	"stuttgart" : "https://netinfo.freifunk-stuttgart.de/FreifunkStuttgart-api.json",
+	"stuttgart" : "https://map.freifunk-stuttgart.de/FreifunkStuttgart-api.json",
 	"suedangeln" : "http://api.ffslfl.net/suedangeln-api.json",
 	"suederbrarup" : "http://api.ffslfl.net/suederbrarup-api.json",
 	"sundern" : "http://map.freifunk-moehne.de/images/sundern/sundern-api.json",


### PR DESCRIPTION
netinfo.freifunk-stuttgart.de will continue to work for a while, but it is planned to redirect to map.freifunk-stuttgart.de in the future. Thus adjust the URL here to avoid the unnecessary redirect.

@Philhil @poldy79 @areyer 