### PR TITLE
Update Url barnstorf

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -23,7 +23,7 @@
 	"badsalzuflen" : "http://api.freifunk-lippe.de/freifunk/ffapi.json",
 	"ballenstedt" : "http://harz.freifunk.net/api.bal.json",
 	"bamberg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/bamberg.json",
-	"barnstorf" : "https://www.meiksbar.de/technik/freifunk/barnstorf.json",
+	"barnstorf" : "https://www.meiksbar.de/files/freifunk/barnstorf.json",
 	"barntrup" : "http://update.freifunk-nordlippe.de/ffapi_barntrup.json",
 	"beilngries" : "https://map.freifunk-altmuehltal.de/data/api/ffbei.json",
 	"berau" : "https://map.freifunk-3laendereck.net/api/community.php?city=Berau&country=DE&community=sswo",


### PR DESCRIPTION
Eingang per Mail:
Hi,
ich habe meine Website in in ein CMS migriert. Da hat sich dann die Dateistruktur geändert:
https://www.meiksbar.de/files/freifunk/barnstorf.json
Gruß Meik Schmidt