### PR TITLE
update location of offenburg/ortenau

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -259,7 +259,7 @@
 	"oelsnitz_vogtland" : "https://mapdata.freifunk-vogtland.net/ffapi-OEL.json",
 	"oeversee" : "http://api.ffslfl.net/oeversee-api.json",
 	"offenbach/queich" : "http://freifunk-suedpfalz.de/FreifunkSuedpfalz-offenbach-api.json",
-	"offenburg" : "https://api.karlsruhe.freifunk.net/ffog.json",
+	"offenburg" : "https://ortenau.freifunk.net/ffapi.json",
 	"oldenburg" : "https://dev.ffnw.de/api_files/Freifunk-Oldenburg-Api.json",
 	"oschatz" : "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkOschatz-api.json",
 	"osnabrueck" : "https://dev.ffnw.de/api_files/Freifunk-Osnabrueck-Api.json",


### PR DESCRIPTION
Ortenau got it's own website again this year, so it only makes sense to move the directory API file there. The API file has also changed (new meetup location).