### PR TITLE
#640 API file of Freifunk Willich deleted

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -382,7 +382,6 @@
 	"wiesbaden" : "https://api.wiesbaden.freifunk.net/ffapi_wi.json",
 	"wiesenburg" : "http://wiki.freifunk.net/images/7/79/Wiesenburg_freifunk_api.json",
 	"wilhelmshaven" : "https://dev.ffnw.de/api_files/Freifunk-Wilhelmshaven-Api.json",
-	"willich" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/willich.json",
 	"winsen" : "http://freifunk.winsener.net/pub/FreifunkWinsen-api.json",
 	"winterbach" : "https://services.freifunk-suedwest.de/ffapi/FreifunkWinterbach-api.json",
 	"winterberg" : "http://map.freifunk-winterberg.net/api/winterberg.json",


### PR DESCRIPTION
API file for willich is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Willich anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed this week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Willich from API directory.

I will delete the old API file of Freifunk Willich from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/willich.json