### PR TITLE
#641 API file of Freifunk Viersen deleted

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -354,7 +354,6 @@
 	"ulm" : "https://raw.githubusercontent.com/ffulm/api/master/api.json",
 	"unna" : "https://wiki.freifunk.net/images/6/6a/FreifunkUnna-api.json",
 	"velbert" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Velbert-api.json",
-	"viersen" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/viersen.json",
 	"villingen-schwenningen" : "https://map.freifunk-3laendereck.net/api/community.php?community=swb&country=DE&city=Schwenningen%20am%20Neckar",
 	"voerde" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/voerde.json",
 	"wachtberg" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/wachtberg.json",


### PR DESCRIPTION
API file for viersen is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Viersen anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed this week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Viersen from API directory.

I will delete the old API file of Freifunk Viersen from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/viersen.json