### PR TITLE
#648 Freifunk Krefeld deleted

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -179,7 +179,6 @@
 	"kollnau" : "https://map.freifunk-3laendereck.net/api/community.php?city=Kollnau&country=DE&community=ffem",
 	"konstanz" : "https://raw.githubusercontent.com/ffbsee/api/master/ffkonstanz.json",
 	"korbach" : "https://freifunk-nordhessen.de/FreifunkKorbach-api.json",
-	"krefeld" : "https://raw.githubusercontent.com/ffniers/ffapi/master/krefeld.json",
 	"kressbronn" : "https://raw.githubusercontent.com/ffbsee/api/master/ffkressbronn.json",
 	"kropp-stapelholm" : "http://api.ffslfl.net/kropp-stapelholm-api.json",
 	"landau" : "http://freifunk-suedpfalz.de/FreifunkSuedpfalz-landau-api.json",


### PR DESCRIPTION
Facebook Page of Freifunk Krefeld was not updated since 2017:
https://www.facebook.com/Freifunk.Krefeld/
Website has gone.
End-of-life notice was published at: https://wiki.freifunk.net/Freifunk_Krefeld

API file for krefeld is outdated.
There is no active Freifunk Community in Krefeld anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed last week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Krefeld from API directory.

Fabian Törper (Freifunk Niersufer) will delete the old API file of Freifunk Krefeld from github repo:
https://raw.githubusercontent.com/ffniers/ffapi/master/krefeld.json
when is has been deleted from API directory.
