### PR TITLE
#651 Freifunk Nettetal is incoporated into Freifunk Niersufer

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -237,7 +237,6 @@
 	"muenster" : "https://karte.freifunk-muensterland.de/data/ffapi.json",
 	"murg" : "https://map.freifunk-3laendereck.net/api/community.php?city=Murg&country=DE&community=saek",
 	"mutschellen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Mutschellen&country=CH&community=ff3l",
-	"nettetal" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/nettetal.json",
 	"neuenburg-am-rhein" : "https://map.freifunk-3laendereck.net/api/community.php?city=Neuenburg+am+Rhein&country=DE&community=bh",
 	"neuendettelsau" : "https://map.freifunk-neuendettelsau.de/data/ffapi.json",
 	"neuenrade" : "https://raw.githubusercontent.com/freifunk-mk/ff-api/master/neuenrade.json",


### PR DESCRIPTION
API file for nettetal is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Nettetal anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed this week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Nettetal from API directory.

I will delete the old API file of Freifunk Nettetal from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/nettetal.json