### PR TITLE
#652 Freifunk Kleve is incoporated into Freifunk Niersufer

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -170,7 +170,6 @@
 	"kitzingen" : "http://freifunk-kitzingen.de/Kitzingen-api.json",
 	"klein-basel" : "https://map.freifunk-3laendereck.net/api/community.php?city=Klein-Basel&country=CH&community=3land",
 	"kleinhueningen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Kleinh%C3%BCningen&country=CH&community=3land",
-	"kleve" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/kleve.json",
 	"koblenz" : "https://map.freifunk-myk.de/ffapi.json",
 	"koblenz-ch" : "https://map.freifunk-3laendereck.net/api/community.php?city=Koblenz&country=CH&community=wtk",
 	"koeln" : "https://kbu.freifunk.net/api/koeln.json",


### PR DESCRIPTION
API file for kleve is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Kleve anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed last week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Kleve from API directory.

I will delete the old API file of Freifunk Kleve from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/kleve.json