### PR TITLE
#656 Freifunk Moers is incoporated into Freifunk Niersufer

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -226,7 +226,6 @@
 	"mittweida" : "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkMittweida-api.json",
 	"moehnesee" : "http://map.freifunk-moehne.de/api/moehnesee.json",
 	"moenchengladbach" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/moenchengladbach.json",
-	"moers" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/moers.json",
 	"moessingen" : "https://map.freifunk-3laendereck.net/api/community.php?community=nalb&country=DE&city=M%C3%B6ssingen",
 	"monheim" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/MonheimamRhein-api.json",
 	"montabaur" : "https://freifunk-westerwald.de/api-mt.json",


### PR DESCRIPTION
API file for moers is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Moers anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed last week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Moers from API directory.

I will delete the old API file of Freifunk Moers from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/moers.json