### PR TITLE
delete eberswalde

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -76,7 +76,6 @@
 	"duesseldorf" : "https://freifunk-duesseldorf.de/api.json",
 	"duisburg" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/duisburg.json",
 	"ebermannstadt" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/ebermannstadt.json",
-	"eberswalde" : "http://ewifi.de/FreifunkEberswalde-api.json",
 	"efringen-kirchen" : "https://map.freifunk-3laendereck.net/api/community.php?city=Efringen-Kirchen&country=DE&community=loe",
 	"eggebek" : "http://api.ffslfl.net/eggebek-api.json",
 	"eggerbach" : "https://wiki.freifunk.net/images/9/9f/FreifunkEggerbach-api.json",


### PR DESCRIPTION
mail vom 7. Juni 2021:
Re: Freifunk API directory[eberswalde]: Eure API Datei ist seit dem 27.01.2021 nicht lesbar.
Hallo,
bitte nehmt unseren Eintrag aus dem Verzeichnis.
Vielen Dank,
Mike Wiebrock