### PR TITLE
#655 Freifunk Mönchengladbach is incoporated into Freifunk Niersufer 

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -221,7 +221,6 @@
 	"mittelangeln" : "http://api.ffslfl.net/mittelangeln-api.json",
 	"mittweida" : "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkMittweida-api.json",
 	"moehnesee" : "http://map.freifunk-moehne.de/api/moehnesee.json",
-	"moenchengladbach" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/moenchengladbach.json",
 	"moessingen" : "https://map.freifunk-3laendereck.net/api/community.php?community=nalb&country=DE&city=M%C3%B6ssingen",
 	"monheim" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/MonheimamRhein-api.json",
 	"montabaur" : "https://freifunk-westerwald.de/api-mt.json",


### PR DESCRIPTION
Clean & fresh PR:

API file for moenchengladbach is outdated.
All its references to Freifunk Ruhrgebiet are dead.
Freifunk Ruhrgebiet died in 2017.
There is no active Freifunk Community in Mönchengladbach anymore.
All its routers had been moved to Freifunk Niersufer, as Fabian Törper confirmed last week.
https://map.freifunk-niersufer.de/#/en/map

Sad to say, but it is time to delete Freifunk Mönchengladbach from API directory.

I will delete the old API file of Freifunk Mönchengladbach from github repo, when is has been deleted from API directory.
https://github.com/Freifunk-Hamm/ffapi/blob/master/moenchengladbach.json

