### PR TITLE
delete hassloch (25.08.2021)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -134,7 +134,6 @@
 	"hartha" : "https://raw.githubusercontent.com/Freifunk-Mittelsachsen/ffmisax-community-files/master/FreifunkHartha-Api.json",
 	"hasel" : "https://api.freifunkkarte.de/wiese/de/hasel/0/json",
 	"hassberge" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/hassberge.json",
-	"hassloch" : "https://www.freifunk-hassloch.de/freifunk-hassloch.json",
 	"heiligenhaus" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Heiligenhaus-api.json",
 	"heilsbronn" : "https://karte.freifunk-heilsbronn.de/data/ffapi.json",
 	"heitersheim" : "https://api.freifunkkarte.de/bh/de/heitersheim/0/json",


### PR DESCRIPTION
Über 9 Monate
25.08.2021 19:01
hassloch, https://www.freifunk-hassloch.de/freifunk-hassloch.json
Freifunk Haßloch, Haßloch
<class 'urllib.error.URLError'> <urlopen error [Errno 113] No route to host>
SocketException: Ein Verbindungsversuch ist fehlgeschlagen, da die Gegenstelle nach einer bestimmten Zeitspanne nicht richtig reagiert hat, oder die hergestellte Verbindung war fehlerhaft, da der verbundene Host nicht reagiert hat 176.9.132.123:443

github@ib-leier.net
