### PR TITLE
delete enkreis (28.08.2021)

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -81,7 +81,6 @@
 	"eltville" : "https://www.freifunk-rtk.de/ffapi_rtk.json",
 	"emmendingen" : "https://api.freifunkkarte.de/ffem/de/emmendingen/0/json",
 	"emskirchen" : "https://karte.freifunk-emskirchen.de/data/ffapi.json",
-	"enkreis" : "https://karte.ff-en.de/ffapi/en.json",
 	"erfurt" : "https://api.erfurt.freifunk.net/freifunk-api.json",
 	"erkrath" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Erkrath-api.json",
 	"erlangen" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/erlangen.json",


### PR DESCRIPTION
Über 9 Monate
28.08.2021 00:01
enkreis, https://karte.ff-en.de/ffapi/en.json
Freifunk im Ennepe-Ruhr-Kreis, Ennepe-Ruhr-Kreis
<class 'urllib.error.HTTPError'> HTTP Error 404: Not Found
WebException: Der Remoteserver hat einen Fehler zurückgegeben: (404) Nicht gefunden.

@Kilobyte22 
Auf meine Mails gibt die ganze Zeit die automatosche Antwort: "In Kürze erhalten Sie eine individuelle Antwort.".
Matthias und Lars hatte ich extra angeschrieben.
Leider gibt es keine weiteren Antworten.

Signed-off-by: O.Leier <github@ib-leier.net>