### PR TITLE
delete augsburg

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -11,7 +11,6 @@
 	"aschaffenburg" : "https://raw.githubusercontent.com/FreifunkFranken/freifunkfranken-community/master/aschaffenburg.json",
 	"ascheberg" : "http://freifunk-ascheberg.de/FreifunkAscheberg-api.json",
 	"auerbach" : "https://mapdata.freifunk-vogtland.net/ffapi-AE.json",
-	"augsburg" : "http://www.wgaugsburg.de/ffapi/ffapi.json",
 	"bad-arolsen" : "https://freifunk-nordhessen.de/FreifunkBadArolsen-api.json",
 	"bad-bellingen" : "https://api.freifunkkarte.de/loe/de/bad-bellingen/0/json",
 	"bad-krozingen" : "https://api.freifunkkarte.de/bh/de/bad-krozingen/0/json",


### PR DESCRIPTION
Email vom 25.07.2022:
Da Freifunk Augsburg nun Teil von Freifunk München ist und auch unsere Infrastruktur und Firmware nutzt, kann Augsburg aus dem API-Verzeichnis entfernt werden.
Mit freundlichen Grüßen
Felix

Signed-off-by: OLeier <github@ib-leier.net>