### PR TITLE
Update Ulm Api to FFMUC Repo

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -328,7 +328,7 @@
 	"ueberlingen" : "https://raw.githubusercontent.com/ffbsee/api/master/ffueberlingen.json",
 	"uehlingen-birkendorf" : "https://api.freifunkkarte.de/sswo/de/uehlingen-birkendorf/0/json",
 	"uelzen" : "https://www.freifunk-uelzen.de/api/FreifunkUelzen-api.json",
-	"ulm" : "https://raw.githubusercontent.com/ffulm/api/master/api.json",
+	"ulm" : "https://raw.githubusercontent.com/freifunkMUC/freifunk.net-API/master/ulm.json",
 	"unna" : "https://wiki.freifunk.net/images/6/6a/FreifunkUnna-api.json",
 	"velbert" : "https://raw.githubusercontent.com/Neanderfunk/communities/master/Velbert-api.json",
 	"voerde" : "https://raw.githubusercontent.com/Freifunk-Hamm/ffapi/master/voerde.json",


### PR DESCRIPTION
as Freifunk Ulm stops operations, ffmuc tries to take over the nodes 

![image](https://github.com/freifunk/directory.api.freifunk.net/assets/5702338/1e40062d-f98e-4efa-b29f-cb5bc8cf5026)
![image](https://github.com/freifunk/directory.api.freifunk.net/assets/5702338/61d4ff1c-3818-4e90-9722-cde6e5d1d24e)

to update the node count arrocding to the new gluon firmware the api is now in our FFMUC Repo