### PR TITLE
update URL for muenchen

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -219,7 +219,7 @@
 	"much" : "https://raw.githubusercontent.com/Freifunk-Rhein-Sieg/api-json/master/much.json",
 	"muehlental" : "https://mapdata.freifunk-vogtland.net/ffapi-MTL.json",
 	"muellheim" : "https://api.freifunkkarte.de/bh/de/muellheim/0/json",
-	"muenchen" : "https://raw.githubusercontent.com/freifunkMUC/freifunk.net-API/master/freifunk.net.json",
+	"muenchen" : "https://raw.githubusercontent.com/freifunkMUC/freifunk.net-API/master/muenchen.json",
 	"muenster" : "https://api.freifunk-muensterland.de/api.json",
 	"murg" : "https://api.freifunkkarte.de/saek/de/murg/0/json",
 	"mutschellen" : "https://api.freifunkkarte.de/ff3l/ch/mutschellen/0/json",


### PR DESCRIPTION
Update github url to muenchen.json so that the different files can be better understood.

https://github.com/freifunkMUC/freifunk.net-API all files are named after the region